### PR TITLE
Provide masking utility to beforeOutput func

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -3,7 +3,7 @@ const morgan = require('morgan');
 const httpContext = require('express-http-context');
 const util = require('util');
 
-const { LOGGER_KEY, options } = require('./options');
+const { LOGGER_KEY, options, mask } = require('./options');
 
 let logger;
 let formatter;
@@ -105,7 +105,13 @@ const baseLoggingHandler = (err, req, res, next) => {
             err
         });
 
-        options.beforeOutput(log);
+        const utils = { mask };
+
+        try {
+            options.beforeOutput(log, utils);
+        } catch (e) {
+            return localLogger.error(e);
+        }
 
         const formatter = getFormatter();
 

--- a/options.js
+++ b/options.js
@@ -1,9 +1,11 @@
 const COMBINED_APACHE_FORMAT = ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"';
 
 const MASK = '[Filtered]';
+const mask = (field) => field && (field = MASK);
+
 const MASK_CREDENTIALS = (log) => {
-    log.headers['authorization'] = MASK;
-    log.fields && log.fields['password'] && (log.fields['password'] = MASK);
+    mask(log.headers['authorization']);
+    log.fields && mask(log.fields['password']);
 };
 
 let OPTIONS = {


### PR DESCRIPTION
Also catches any failure during executing `beforeOutput()` (like when accessing a undefined field)